### PR TITLE
Fix 6 bugs from deep site audit

### DIFF
--- a/content/en/templates/_index.md
+++ b/content/en/templates/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Documentation Templates — Valoryx"
+title: "Documentation Templates"
 description: "6 ready-to-use documentation templates: API docs, knowledge base, open source, changelog, AI-maintained, and compliance. Git-native, free."
 layout: list
 ---

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -856,7 +856,9 @@ other = "Compare Plans"
 [pricing_enterprise_note]
 other = "Need more? "
 [pricing_enterprise_cta]
-other = "Contact us for Enterprise pricing"
+other = "Need more?"
+[pricing_enterprise_suffix]
+other = "for Enterprise pricing."
 [pricing_faq_title]
 other = "Frequently Asked Questions"
 [pfaq1_q]

--- a/layouts/install/list.html
+++ b/layouts/install/list.html
@@ -265,6 +265,7 @@
           <div><span class="success">Server running at http://localhost:3000</span></div>
         </div>
       </div>
+      <p class="text-sm mb-4" style="color: var(--body);">Open <code class="text-xs px-1.5 py-0.5 rounded" style="background: rgba(29,127,194,0.08);">http://localhost:3000</code> in your browser to create your first account and workspace.</p>
       <h4 class="text-base font-bold mb-3" style="color: var(--heading);">What's Next</h4>
       <div class="space-y-2">
         <a href="{{ "docs/getting-started/quickstart/" | relLangURL }}" class="block text-sm font-semibold no-underline" style="color: var(--accent);"><i class="bi bi-arrow-right mr-1"></i> Quick Start Guide</a>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,7 +26,13 @@
 
   <!-- Open Graph -->
   {{ $ogImage := .Params.ogImage | default "/images/og-default.png" | absURL }}
+  {{ if eq .Section "blog" }}
+  <meta property="og:type"        content="article">
+  {{ if .Date }}<meta property="article:published_time" content="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ end }}
+  {{ if .Lastmod }}<meta property="article:modified_time" content="{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}">{{ end }}
+  {{ else }}
   <meta property="og:type"        content="website">
+  {{ end }}
   <meta property="og:url"         content="{{ .Permalink }}">
   <meta property="og:title"       content="{{ $pageTitle }}">
   <meta property="og:description" content="{{ $pageDesc }}">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -36,7 +36,7 @@
       </nav>
 
       <!-- CTA Button -->
-      <a href="{{ $homeURL }}#get-started" class="hidden lg:inline-block btn-glow bg-navy text-white px-5 py-2 rounded-lg text-[13px] font-semibold hover:bg-navy-light active:scale-[0.97] no-underline" style="transition: transform 200ms cubic-bezier(0.34,1.56,0.64,1), background 200ms ease;">
+      <a href="{{ $homeURL }}install/" class="hidden lg:inline-block btn-glow bg-navy text-white px-5 py-2 rounded-lg text-[13px] font-semibold hover:bg-navy-light active:scale-[0.97] no-underline" style="transition: transform 200ms cubic-bezier(0.34,1.56,0.64,1), background 200ms ease;">
         {{ i18n "nav_cta" }}
       </a>
 

--- a/layouts/vs/single.html
+++ b/layouts/vs/single.html
@@ -12,7 +12,7 @@
       </span>
     </div>
     <h1 class="text-3xl sm:text-4xl md:text-5xl font-extrabold leading-tight mb-6 reveal" style="color: var(--heading); letter-spacing: -0.04em;">
-      {{ i18n "vs_hero_title" | default (printf "Valoryx vs %s" $competitor) }}
+      {{ (i18n "vs_hero_title" | default "Valoryx vs %s") | replace "%s" $competitor }}
     </h1>
     <p class="mx-auto max-w-2xl text-base sm:text-lg reveal" style="color: var(--muted); line-height: 1.8;">
       {{ i18n "vs_hero_subtitle" | default "A fair comparison for developer documentation." }}
@@ -172,7 +172,7 @@
   <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
 
     <div class="section-title reveal">
-      <h2>{{ i18n "vs_competitor_wins_title" | default (printf "Where %s Wins" $competitor) }}</h2>
+      <h2>{{ (i18n "vs_competitor_wins_title" | default "Where %s Wins") | replace "%s" $competitor }}</h2>
       <p>{{ i18n "vs_competitor_wins_subtitle" | default "We believe in honest comparisons. Here is where the competition has an edge." }}</p>
     </div>
 


### PR DESCRIPTION
## Summary

Deep Playwright + manual audit of all 54 pages found 6 concrete bugs. All fixed.

### Bugs Fixed

| # | Page | Bug | Impact |
|---|------|-----|--------|
| 1 | `/vs/gitbook/` | H1 shows literal `%s` instead of "GitBook" | **Broken page visible to high-intent visitors** |
| 2 | `/pricing/` | "Enterprise pricing" text duplicated | Looks unprofessional |
| 3 | `/templates/` | Title tag: "...Valoryx — Valoryx" (double suffix) | SEO: duplicate brand in title |
| 4 | `/blog/*` | `og:type` was "website" instead of "article" | Social sharing + search classification wrong |
| 5 | Nav header | CTA linked to `/#get-started` instead of `/install/` | Download path buried behind scroll |
| 6 | `/install/` | No instruction to open localhost:3000 after install | Users stuck after running `docplatform serve` |

### Verification
- Hugo build: PASS (zero errors)
- All fixes verified against rendered output
- No regressions in other pages

### Strategic Improvements (not in this PR — for future)
These don't have code fixes but would move the needle:
- Add product screenshots to homepage (biggest conversion gap)
- Add pricing comparison with actual GitBook/Notion prices to /vs/ pages
- Add `/.well-known/security.txt`
- Self-host fonts (eliminate Google Fonts render-blocking)
- Custom 404 page with helpful navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)