### PR TITLE
Add Coming Soon badge + Get in Touch CTA on Business plan

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -822,7 +822,9 @@ other = "You own your data"
 [pricing_download]
 other = "Download"
 [pricing_contact]
-other = "Contact us"
+other = "Kontakt aufnehmen"
+[pricing_coming_soon]
+other = "Demnächst verfügbar"
 [pricing_compare_title]
 other = "Compare Plans"
 [pricing_enterprise_note]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -850,7 +850,9 @@ other = "You own your data"
 [pricing_download]
 other = "Download"
 [pricing_contact]
-other = "Contact us"
+other = "Get in Touch"
+[pricing_coming_soon]
+other = "Coming Soon"
 [pricing_compare_title]
 other = "Compare Plans"
 [pricing_enterprise_note]

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -822,7 +822,9 @@ other = "You own your data"
 [pricing_download]
 other = "Download"
 [pricing_contact]
-other = "Contact us"
+other = "Contáctenos"
+[pricing_coming_soon]
+other = "Próximamente"
 [pricing_compare_title]
 other = "Compare Plans"
 [pricing_enterprise_note]

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -822,7 +822,9 @@ other = "You own your data"
 [pricing_download]
 other = "Download"
 [pricing_contact]
-other = "Contact us"
+other = "Nous contacter"
+[pricing_coming_soon]
+other = "Bientôt disponible"
 [pricing_compare_title]
 other = "Compare Plans"
 [pricing_enterprise_note]

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -822,7 +822,9 @@ other = "You own your data"
 [pricing_download]
 other = "Download"
 [pricing_contact]
-other = "Contact us"
+other = "Связаться с нами"
+[pricing_coming_soon]
+other = "Скоро"
 [pricing_compare_title]
 other = "Compare Plans"
 [pricing_enterprise_note]

--- a/i18n/uk.toml
+++ b/i18n/uk.toml
@@ -822,7 +822,9 @@ other = "You own your data"
 [pricing_download]
 other = "Download"
 [pricing_contact]
-other = "Contact us"
+other = "Зв'язатися з нами"
+[pricing_coming_soon]
+other = "Незабаром"
 [pricing_compare_title]
 other = "Compare Plans"
 [pricing_enterprise_note]

--- a/layouts/partials/sections/pricing.html
+++ b/layouts/partials/sections/pricing.html
@@ -73,21 +73,22 @@
 
       <!-- Cloud Business -->
       <div class="reveal reveal-delay-4">
-        <div class="pricing-item">
+        <div class="pricing-item" style="opacity: 0.85;">
           <div class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider mb-3" style="background: rgba(29,127,194,0.08); color: var(--accent);">
             <i class="bi bi-cloud text-[9px]"></i> {{ i18n "pricing_cloud_short" | default "Cloud" }}
           </div>
+          <span class="inline-block px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider mb-2" style="background: rgba(255,171,0,0.12); color: #b37400; width: fit-content;">{{ i18n "pricing_coming_soon" | default "Coming Soon" }}</span>
           <h3>{{ i18n "plan_business" }}</h3>
           <p class="plan-persona">{{ i18n "pricing_persona_business" | default "For orgs that need security and scale" }}</p>
           <h4><sup>$</sup>79 <span>/ {{ i18n "plan_mo" | default "mo" }}</span></h4>
           <ul>
             <li><i class="bi bi-check"></i> {{ i18n "pb_feat1" | default "10 Workspaces" }}</li>
             <li><i class="bi bi-check"></i> {{ i18n "pb_feat2" | default "50 Editors" }}</li>
-            <li><i class="bi bi-check"></i> {{ i18n "pb_feat3" | default "500 Pages per Workspace" }}</li>
+            <li><i class="bi bi-check"></i> {{ i18n "pb_feat3" | default "Unlimited Published Pages" }}</li>
             <li><i class="bi bi-check"></i> {{ i18n "pb_feat5" | default "SSO / SAML" }}</li>
             <li><i class="bi bi-check"></i> {{ i18n "pb_feat7" | default "Audit Logs" }}</li>
           </ul>
-          <a href="#contact" class="buy-btn" aria-label="Contact Us">{{ i18n "pricing_contact" | default "Contact Us" }}</a>
+          <a href="#contact" class="buy-btn" aria-label="Get in Touch">{{ i18n "pricing_coming_soon" | default "Coming Soon" }} — {{ i18n "pricing_contact" | default "Get in Touch" }}</a>
           <p class="text-xs mt-3" style="color: var(--muted);">{{ i18n "pricing_enterprise_note" | default "Custom plans available for larger teams" }}</p>
         </div>
       </div>

--- a/layouts/pricing/list.html
+++ b/layouts/pricing/list.html
@@ -105,10 +105,11 @@
 
       <!-- Cloud Business -->
       <div class="reveal reveal-delay-4">
-        <div class="pricing-item flex flex-col">
+        <div class="pricing-item flex flex-col" style="opacity: 0.85;">
           <div class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider mb-3" style="background: rgba(29,127,194,0.08); color: var(--accent);">
             <i class="bi bi-cloud text-[9px]"></i> {{ i18n "pricing_cloud_label" | default "Cloud" }}
           </div>
+          <span class="inline-block px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider mb-2" style="background: rgba(255,171,0,0.12); color: #b37400; width: fit-content;">{{ i18n "pricing_coming_soon" | default "Coming Soon" }}</span>
           <h3>{{ i18n "plan_business" | default "Business" }}</h3>
           <p class="text-xs mb-4" style="color: var(--muted);">{{ i18n "pricing_persona_business" | default "For orgs that need security and scale" }}</p>
           <h4><sup>$</sup>79 <span>/ {{ i18n "plan_mo" | default "mo" }}</span></h4>
@@ -121,7 +122,7 @@
             <li><i class="bi bi-check"></i> {{ i18n "pb_feat7" | default "Audit Logs" }}</li>
           </ul>
           <div class="mt-auto pt-4">
-            <a href="{{ $homeURL }}#contact" class="buy-btn">{{ i18n "pricing_contact" | default "Contact Us" }}</a>
+            <a href="{{ $homeURL }}#contact" class="buy-btn">{{ i18n "pricing_coming_soon" | default "Coming Soon" }} — {{ i18n "pricing_contact" | default "Get in Touch" }}</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Business tier is not yet available. The pricing cards now clearly signal this:

- **"Coming Soon" badge** in amber/gold on the Business card
- **Button text changed** from "Contact Us" to "Coming Soon — Get in Touch"
- **Button links to `#contact`** section (contact form)
- **Card slightly dimmed** (opacity 0.85) to visually distinguish from available plans

Applied to both pricing surfaces:
- `/pricing/` (dedicated pricing page)
- Homepage pricing section (partial)

Also fixed:
- Homepage pricing partial had stale `pb_feat3` default ("500 Pages per Workspace" → "Unlimited Published Pages")
- `pricing_contact` updated to "Get in Touch" in all 6 languages
- `pricing_coming_soon` key added in all 6 languages (EN, DE, ES, FR, RU, UK)

## Verification
- **Hugo build:** PASS
- **Pricing page:** "Coming Soon" badge + button renders correctly
- **Homepage:** Same — Coming Soon badge + button on Business card
- **Zero "500 Pages" remaining** on any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)