### PR TITLE
chore: add PR body template (Phase 1 review protocol)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Why
+<!-- 1-2 sentences: the user ask or handoff issue # driving this change -->
+
+## Approach
+<!-- What this PR does and why. Pages/templates/i18n files affected. -->
+
+## Alternatives Considered
+<!-- At least one — "none" is valid but must be explicit. -->
+
+## Self-Identified Risks
+<!-- e.g., "pricing claim — verified against plans.go", "new page not yet translated to UK/RU", "CTA link not yet tracked in analytics". Cannot be empty. -->
+
+## Verification Log
+<!-- Concrete evidence:
+- hugo --minify (PASS/FAIL)
+- pricing grep vs internal/billing/plans.go
+- feature grep vs internal/
+- internal-link check
+- i18n coverage (new keys per language: EN, UK, RU, FR, ...) -->
+
+## Context Snapshot
+<!-- Paste the RAW contents of your sessions/active-context.md at PR-open time. -->
+
+## Linked
+- Handoff issue: <!-- #N or "none" -->
+- Related PRs: <!-- #M or "none" -->
+- Related issues: <!-- #J or "none" -->


### PR DESCRIPTION
## Why

Phase 1 of the review protocol mandates that every PR body follow the canonical 7-section template (`.workspace/PR-BODY-TEMPLATE.md`). Adding `.github/pull_request_template.md` to valoryx.org means GitHub auto-populates the form for humans and agents alike, making compliance the default path.

Re-scoped from closed #19 per handoff #10: the prior PR bundled unrelated MCP marketing-page edits that the review gate flagged as out-of-scope and containing unverified product claims. This PR carries only the template file.

## Approach

- Branch cut from fresh `main`.
- Single file added: `.github/pull_request_template.md`, content copied verbatim from the file previously staged on `build/add-pr-template` in closed #19 (identical to the canonical template in `.workspace/PR-BODY-TEMPLATE.md`).
- No changes to site content, layouts, or i18n.

## Alternatives Considered

- **Force-push a reduced diff onto the old #19 branch (Option A).** Rejected: commingling the template change with the reviewer's blocked changes would obscure the audit trail and still leave the MCP rework owned by the wrong agent.
- **Inline the MCP fixes here and re-request review.** Rejected: MCP marketing page is growth-agent's domain; product claims ("24 tools", cloud status, auth/ports) need source-of-truth verification per growth's verify-before-publish rule.

## Self-Identified Risks

- Low. Pure docs addition, no runtime or content impact. Worst case: template text needs wording tweaks — reviewer can request edits. No user-visible behavior changes on the marketing site.

## Verification Log

- `git diff --cached --stat` after staging: `.github/pull_request_template.md | 27 +++++++++++++++++++++++++++` — single file, 27 lines added.
- Branch history: cut from `origin/main` at current HEAD; only one commit.
- No Go / Hugo / JS source files touched → no build or lint impact on the site.
- Hugo does not parse `.github/*`, so no deploy-time risk on Cloudflare Pages.

## Context Snapshot

```markdown
---
agent: build-agent
session_started: 2026-04-12
last_updated: 2026-04-12T-handoff10-rework
north_star: Process Phase 1 PR review queue — rework blocked PR #19
current_task: Option B split of PR #19 — close old, open clean template-only PR, handoff MCP content to growth-agent
next_action: After PR A opens and handoff to growth filed, end session. Do NOT review the rework PR in this session (never-self-merge).
status: active
---

## Decisions & Why
- Chose Option B (split) over Option A (revert). MCP marketing content crosses into growth-agent's domain (marketing voice + product claims), and auth/port/tool-count claims need source verification that growth's verify-before-publish rule enforces. Cleaner to not commingle.
- Closed PR #19 rather than force-push a reduced diff, so history reflects the scope decision.
- Branch `build/add-pr-template-clean` cut from fresh `main`; only cherry-picked `.github/pull_request_template.md` from the old branch.

## Files Touched This Session
- sessions/active-context.md (checkpoint)
- valoryx.org `.github/pull_request_template.md` (staged on new branch, content unchanged from #19)

## Open Artifacts
- PRs: #2 (awaiting human merge), #246 (awaiting CI), #19 CLOSED, new template-only PR to be opened this session
- Handoffs: #7 open, #9 open, #10 open (this rework), new handoff to growth-agent for MCP content to be filed
- Branches active: build/add-pr-template-clean (valoryx.org)

## Blocking Questions
- none

## Do-Not-Lose
- Reviewer findings on old #19: unverified "24 tools" + "Available now" cloud claim, stale i18n in uk/ru/fr/de/es/zh, null-template Context Snapshot. All deferred to growth-agent handoff.
- Labels `needs-author-fix` / `blocked-pr` don't exist in all repos — create before PR-ops workflow needs them.

## Resume Hints
- To re-review the new template PR: file a handoff with `review-requested` label; a future build-agent session processes it (fresh-context skeptic requirement).
- Old branch `build/add-pr-template` on valoryx.org can be deleted once the new PR merges.
```

## Linked

- Closes handoff #10 (Valoryx-org/issues) — rework of scope-split decision
- Replaces closed PR #19 (Valoryx-org/valoryx.org)
- Companion handoff to growth-agent (to be filed this session) covers the MCP marketing content
