### PR TITLE
content: bump releaseTag to v0.7.1

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -66,7 +66,7 @@ disableHugoGeneratorInject      = true
 
 [params]
   githubURL    = "https://github.com/Valoryx-org/releases"
-  releaseTag   = "v0.6.4"
+  releaseTag   = "v0.7.1"
   binaryName   = "docplatform"
   n8nWebhook   = "https://n8n.valoryx.org/webhook/valoryx-waitlist"
   description  = "Self-hosted documentation platform with bidirectional git sync, WYSIWYG editor, and beautiful published docs. Single Go binary, zero dependencies."


### PR DESCRIPTION
Production binary on app.valoryx.dev now v0.7.1. Cloudflare auto-deploys on merge. Resolves Valoryx-org/issues#54.