### PR TITLE
growth: site truth pass — trial/annual LIVE, SSO/audit-logs coming-soon, signed claim, GDPR callout (×6 locales)

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -198,7 +198,7 @@ other = "Ihre Dokumentation wird als Standard-Markdown-Dateien in einem Git-Repo
 [faq6_q]
 other = "Unterstützt Valoryx mehrere Arbeitsbereiche?"
 [faq6_a]
-other = "Ja. Team- und Business-Pläne unterstützen unbegrenzte Arbeitsbereiche, SSO-Integration, Audit-Logging und granulare rollenbasierte Zugriffskontrolle."
+other = "Ja. Die Community Edition unterstützt unbegrenzte Arbeitsbereiche und Editoren. Cloud Free umfasst 1 Arbeitsbereich mit 3 Editoren, Team 3 Arbeitsbereiche mit 15 Editoren und Business 10 Arbeitsbereiche mit 50 Editoren. Jeder Arbeitsbereich ist mit seinem eigenen Git-Repository mit unabhängigen Berechtigungen verbunden."
 
 [contact_title]
 other = "Kontakt"
@@ -738,7 +738,7 @@ other = "Ask questions, share ideas, and connect with other users."
 [oss_cta_title]
 other = "Need more than Community Edition?"
 [oss_cta_text]
-other = "Valoryx Enterprise adds SSO, advanced analytics, priority support, and unlimited editors."
+other = "Valoryx Enterprise adds SSO/SAML (on request), advanced analytics, priority support, and unlimited editors."
 [oss_cta_btn_pricing]
 other = "View Pricing"
 [oss_cta_btn_contact]
@@ -802,11 +802,11 @@ other = "50 Editors"
 [pb_feat3]
 other = "500 Seiten pro Arbeitsbereich"
 [pb_feat5]
-other = "SSO / SAML"
+other = "SSO / SAML (coming soon)"
 [pb_feat6]
 other = "Analytics Dashboard"
 [pb_feat7]
-other = "Audit Logs"
+other = "Audit Logs (coming soon)"
 [pricing_community]
 other = "Community Edition"
 [pce_feat1]
@@ -842,11 +842,11 @@ other = "Yes. Since Valoryx is git-native, your content syncs to a git repositor
 [pfaq3_q]
 other = "Do you offer annual billing?"
 [pfaq3_a]
-other = "Coming soon with a 20% discount. Start with monthly billing today."
+other = "Yes - annual billing is live. Pay for 10 months and get 12 (two months free versus paying monthly). Switch between monthly and annual anytime."
 [pfaq4_q]
 other = "Is there a trial period?"
 [pfaq4_a]
-other = "Coming soon. In the meantime, start with the Free tier."
+other = "Yes - every paid plan starts with a 14-day free trial. No charge until it ends, and you can cancel anytime."
 [pfaq5_q]
 other = "What happens if I exceed my plan limits?"
 [pfaq5_a]
@@ -910,7 +910,7 @@ other = "Built with security best practices at every layer."
 [security_infra_binary_title]
 other = "Signed Binaries"
 [security_infra_binary_text]
-other = "All releases signed with Sigstore cosign. SBOM included. Reproducible builds via GoReleaser."
+other = "Linux and macOS binaries (v0.11.4 and later) are signed with Sigstore cosign keyless signatures. Every release ships an SBOM and checksums."
 [security_infra_scanning_title]
 other = "Dependency Scanning"
 [security_infra_scanning_text]
@@ -991,3 +991,17 @@ other = "MCP Tools"
 other = "Nutzungsbedingungen"
 [footer_privacy]
 other = "Datenschutzrichtlinie"
+
+# ops#142 GDPR portability/erasure callout (security page)
+[security_privacy_title]
+other = "Datenschutz & Datenkontrolle"
+[security_privacy_subtitle]
+other = "Ihre Daten gehören Ihnen - mitnehmen oder löschen, ganz ohne Support-Ticket."
+[security_privacy_export_title]
+other = "Self-Service-Export"
+[security_privacy_export_text]
+other = "Cloud-Kunden exportieren alles - Arbeitsbereiche, Mitglieder, Uploads, Rechnungsverlauf - jederzeit als einzelnen Download. Die Community Edition behält Ihre Inhalte als Markdown in Ihrem eigenen Git-Repository."
+[security_privacy_delete_title]
+other = "Recht auf Löschung"
+[security_privacy_delete_text]
+other = "Löschen Sie Ihr Konto selbst in den Einstellungen, mit Passwortbestätigung. Wir anonymisieren Ihre personenbezogenen Daten und wahren dabei die Audit-Integrität, gemäß der DSGVO-Datenminimierung. (Nur-SSO-Konten: Support kontaktieren.)"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -766,7 +766,7 @@ other = "Ask questions, share ideas, and connect with other users."
 [oss_cta_title]
 other = "Need more than Community Edition?"
 [oss_cta_text]
-other = "Valoryx Enterprise adds SSO, advanced analytics, priority support, and unlimited editors."
+other = "Valoryx Enterprise adds SSO/SAML (on request), advanced analytics, priority support, and unlimited editors."
 [oss_cta_btn_pricing]
 other = "View Pricing"
 [oss_cta_btn_contact]
@@ -830,11 +830,11 @@ other = "50 Editors"
 [pb_feat3]
 other = "500 Pages per Workspace"
 [pb_feat5]
-other = "SSO / SAML"
+other = "SSO / SAML (coming soon)"
 [pb_feat6]
 other = "Analytics Dashboard"
 [pb_feat7]
-other = "Audit Logs"
+other = "Audit Logs (coming soon)"
 [pricing_community]
 other = "Community Edition"
 [pce_feat1]
@@ -870,11 +870,11 @@ other = "Yes. Since Valoryx is git-native, your content syncs to a git repositor
 [pfaq3_q]
 other = "Do you offer annual billing?"
 [pfaq3_a]
-other = "Coming soon with a 20% discount. Start with monthly billing today."
+other = "Yes - annual billing is live. Pay for 10 months and get 12 (two months free versus paying monthly). Switch between monthly and annual anytime."
 [pfaq4_q]
 other = "Is there a trial period?"
 [pfaq4_a]
-other = "Coming soon. In the meantime, start with the Free tier."
+other = "Yes - every paid plan starts with a 14-day free trial. No charge until it ends, and you can cancel anytime."
 [pfaq5_q]
 other = "What happens if I exceed my plan limits?"
 [pfaq5_a]
@@ -938,7 +938,7 @@ other = "Built with security best practices at every layer."
 [security_infra_binary_title]
 other = "Signed Binaries"
 [security_infra_binary_text]
-other = "All releases signed with Sigstore cosign. SBOM included. Reproducible builds via GoReleaser."
+other = "Linux and macOS binaries (v0.11.4 and later) are signed with Sigstore cosign keyless signatures. Every release ships an SBOM and checksums."
 [security_infra_scanning_title]
 other = "Dependency Scanning"
 [security_infra_scanning_text]
@@ -1019,3 +1019,17 @@ other = "MCP Tools"
 other = "Terms of Service"
 [footer_privacy]
 other = "Privacy Policy"
+
+# ops#142 GDPR portability/erasure callout (security page)
+[security_privacy_title]
+other = "Privacy & Data Control"
+[security_privacy_subtitle]
+other = "Your data is yours - take it or delete it, no support ticket required."
+[security_privacy_export_title]
+other = "Self-Service Export"
+[security_privacy_export_text]
+other = "Cloud customers export everything - workspaces, members, uploads, billing history - as a single download, anytime. Community Edition keeps your content as Markdown in your own git repository."
+[security_privacy_delete_title]
+other = "Right to Erasure"
+[security_privacy_delete_text]
+other = "Delete your account yourself from settings, password-confirmed. We anonymize your personal data while preserving audit integrity, in line with GDPR data minimization. (SSO-only accounts: contact support.)"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -198,7 +198,7 @@ other = "Tu documentación se almacena como archivos Markdown estándar en un re
 [faq6_q]
 other = "¿Valoryx admite múltiples espacios de trabajo?"
 [faq6_a]
-other = "Sí. Los planes Equipo y Empresa admiten espacios ilimitados, integración SSO, audit logging y control de acceso granular basado en roles."
+other = "Sí. La Community Edition admite espacios de trabajo y editores ilimitados. Cloud Free incluye 1 espacio de trabajo con 3 editores, Team 3 espacios de trabajo con 15 editores y Business 10 espacios de trabajo con 50 editores. Cada espacio de trabajo se conecta a su propio repositorio git con permisos independientes."
 
 [contact_title]
 other = "Ponerse en Contacto"
@@ -738,7 +738,7 @@ other = "Ask questions, share ideas, and connect with other users."
 [oss_cta_title]
 other = "Need more than Community Edition?"
 [oss_cta_text]
-other = "Valoryx Enterprise adds SSO, advanced analytics, priority support, and unlimited editors."
+other = "Valoryx Enterprise adds SSO/SAML (on request), advanced analytics, priority support, and unlimited editors."
 [oss_cta_btn_pricing]
 other = "View Pricing"
 [oss_cta_btn_contact]
@@ -802,11 +802,11 @@ other = "50 Editors"
 [pb_feat3]
 other = "500 Páginas por Espacio de Trabajo"
 [pb_feat5]
-other = "SSO / SAML"
+other = "SSO / SAML (coming soon)"
 [pb_feat6]
 other = "Analytics Dashboard"
 [pb_feat7]
-other = "Audit Logs"
+other = "Audit Logs (coming soon)"
 [pricing_community]
 other = "Community Edition"
 [pce_feat1]
@@ -842,11 +842,11 @@ other = "Yes. Since Valoryx is git-native, your content syncs to a git repositor
 [pfaq3_q]
 other = "Do you offer annual billing?"
 [pfaq3_a]
-other = "Coming soon with a 20% discount. Start with monthly billing today."
+other = "Yes - annual billing is live. Pay for 10 months and get 12 (two months free versus paying monthly). Switch between monthly and annual anytime."
 [pfaq4_q]
 other = "Is there a trial period?"
 [pfaq4_a]
-other = "Coming soon. In the meantime, start with the Free tier."
+other = "Yes - every paid plan starts with a 14-day free trial. No charge until it ends, and you can cancel anytime."
 [pfaq5_q]
 other = "What happens if I exceed my plan limits?"
 [pfaq5_a]
@@ -910,7 +910,7 @@ other = "Built with security best practices at every layer."
 [security_infra_binary_title]
 other = "Signed Binaries"
 [security_infra_binary_text]
-other = "All releases signed with Sigstore cosign. SBOM included. Reproducible builds via GoReleaser."
+other = "Linux and macOS binaries (v0.11.4 and later) are signed with Sigstore cosign keyless signatures. Every release ships an SBOM and checksums."
 [security_infra_scanning_title]
 other = "Dependency Scanning"
 [security_infra_scanning_text]
@@ -991,3 +991,17 @@ other = "MCP Tools"
 other = "Términos de servicio"
 [footer_privacy]
 other = "Política de privacidad"
+
+# ops#142 GDPR portability/erasure callout (security page)
+[security_privacy_title]
+other = "Privacidad y control de datos"
+[security_privacy_subtitle]
+other = "Tus datos son tuyos: llévatelos o elimínalos, sin ticket de soporte."
+[security_privacy_export_title]
+other = "Exportación de autoservicio"
+[security_privacy_export_text]
+other = "Los clientes de Cloud exportan todo - espacios de trabajo, miembros, archivos subidos, historial de facturación - como una sola descarga, en cualquier momento. La Community Edition mantiene tu contenido como Markdown en tu propio repositorio git."
+[security_privacy_delete_title]
+other = "Derecho al olvido"
+[security_privacy_delete_text]
+other = "Elimina tu cuenta tú mismo desde los ajustes, con confirmación por contraseña. Anonimizamos tus datos personales preservando la integridad de la auditoría, conforme a la minimización de datos del RGPD. (Cuentas solo con SSO: contacta con soporte.)"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -198,7 +198,7 @@ other = "Votre documentation est stockée sous forme de fichiers Markdown standa
 [faq6_q]
 other = "Valoryx supporte-t-il plusieurs espaces de travail ?"
 [faq6_a]
-other = "Oui. Les plans Équipe et Entreprise supportent des espaces illimités, l'intégration SSO, l'audit logging et le contrôle d'accès granulaire par rôle."
+other = "Oui. La Community Edition prend en charge un nombre illimité d'espaces de travail et d'éditeurs. Cloud Free inclut 1 espace de travail avec 3 éditeurs, Team 3 espaces de travail avec 15 éditeurs et Business 10 espaces de travail avec 50 éditeurs. Chaque espace de travail se connecte à son propre dépôt git avec des permissions indépendantes."
 
 [contact_title]
 other = "Nous Contacter"
@@ -738,7 +738,7 @@ other = "Ask questions, share ideas, and connect with other users."
 [oss_cta_title]
 other = "Need more than Community Edition?"
 [oss_cta_text]
-other = "Valoryx Enterprise adds SSO, advanced analytics, priority support, and unlimited editors."
+other = "Valoryx Enterprise adds SSO/SAML (on request), advanced analytics, priority support, and unlimited editors."
 [oss_cta_btn_pricing]
 other = "View Pricing"
 [oss_cta_btn_contact]
@@ -802,11 +802,11 @@ other = "50 Editors"
 [pb_feat3]
 other = "500 Pages par Espace de Travail"
 [pb_feat5]
-other = "SSO / SAML"
+other = "SSO / SAML (coming soon)"
 [pb_feat6]
 other = "Analytics Dashboard"
 [pb_feat7]
-other = "Audit Logs"
+other = "Audit Logs (coming soon)"
 [pricing_community]
 other = "Community Edition"
 [pce_feat1]
@@ -842,11 +842,11 @@ other = "Yes. Since Valoryx is git-native, your content syncs to a git repositor
 [pfaq3_q]
 other = "Do you offer annual billing?"
 [pfaq3_a]
-other = "Coming soon with a 20% discount. Start with monthly billing today."
+other = "Yes - annual billing is live. Pay for 10 months and get 12 (two months free versus paying monthly). Switch between monthly and annual anytime."
 [pfaq4_q]
 other = "Is there a trial period?"
 [pfaq4_a]
-other = "Coming soon. In the meantime, start with the Free tier."
+other = "Yes - every paid plan starts with a 14-day free trial. No charge until it ends, and you can cancel anytime."
 [pfaq5_q]
 other = "What happens if I exceed my plan limits?"
 [pfaq5_a]
@@ -910,7 +910,7 @@ other = "Built with security best practices at every layer."
 [security_infra_binary_title]
 other = "Signed Binaries"
 [security_infra_binary_text]
-other = "All releases signed with Sigstore cosign. SBOM included. Reproducible builds via GoReleaser."
+other = "Linux and macOS binaries (v0.11.4 and later) are signed with Sigstore cosign keyless signatures. Every release ships an SBOM and checksums."
 [security_infra_scanning_title]
 other = "Dependency Scanning"
 [security_infra_scanning_text]
@@ -991,3 +991,17 @@ other = "MCP Tools"
 other = "Conditions d'utilisation"
 [footer_privacy]
 other = "Politique de confidentialité"
+
+# ops#142 GDPR portability/erasure callout (security page)
+[security_privacy_title]
+other = "Confidentialité et contrôle des données"
+[security_privacy_subtitle]
+other = "Vos données vous appartiennent : emportez-les ou supprimez-les, sans ticket de support."
+[security_privacy_export_title]
+other = "Export en libre-service"
+[security_privacy_export_text]
+other = "Les clients Cloud exportent tout - espaces de travail, membres, fichiers, historique de facturation - en un seul téléchargement, à tout moment. La Community Edition conserve votre contenu en Markdown dans votre propre dépôt git."
+[security_privacy_delete_title]
+other = "Droit à l'effacement"
+[security_privacy_delete_text]
+other = "Supprimez votre compte vous-même depuis les paramètres, avec confirmation par mot de passe. Nous anonymisons vos données personnelles tout en préservant l'intégrité de l'audit, conformément à la minimisation des données du RGPD. (Comptes SSO uniquement : contactez le support.)"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -198,7 +198,7 @@ other = "Ваша документация хранится как станда�
 [faq6_q]
 other = "Valoryx поддерживает несколько рабочих пространств?"
 [faq6_a]
-other = "Да. Планы Team и Business поддерживают неограниченное количество рабочих пространств, интеграцию SSO, audit logging и гранулярный контроль доступа на основе ролей."
+other = "Да. Community Edition поддерживает неограниченное количество рабочих пространств и редакторов. Cloud Free включает 1 рабочее пространство с 3 редакторами, Team — 3 рабочих пространства с 15 редакторами, а Business — 10 рабочих пространств с 50 редакторами. Каждое рабочее пространство подключается к собственному git-репозиторию с независимыми правами доступа."
 
 [contact_title]
 other = "Связаться с Нами"
@@ -738,7 +738,7 @@ other = "Ask questions, share ideas, and connect with other users."
 [oss_cta_title]
 other = "Need more than Community Edition?"
 [oss_cta_text]
-other = "Valoryx Enterprise adds SSO, advanced analytics, priority support, and unlimited editors."
+other = "Valoryx Enterprise adds SSO/SAML (on request), advanced analytics, priority support, and unlimited editors."
 [oss_cta_btn_pricing]
 other = "View Pricing"
 [oss_cta_btn_contact]
@@ -802,11 +802,11 @@ other = "50 Editors"
 [pb_feat3]
 other = "500 Страниц на Рабочее Пространство"
 [pb_feat5]
-other = "SSO / SAML"
+other = "SSO / SAML (coming soon)"
 [pb_feat6]
 other = "Analytics Dashboard"
 [pb_feat7]
-other = "Audit Logs"
+other = "Audit Logs (coming soon)"
 [pricing_community]
 other = "Community Edition"
 [pce_feat1]
@@ -842,11 +842,11 @@ other = "Yes. Since Valoryx is git-native, your content syncs to a git repositor
 [pfaq3_q]
 other = "Do you offer annual billing?"
 [pfaq3_a]
-other = "Coming soon with a 20% discount. Start with monthly billing today."
+other = "Yes - annual billing is live. Pay for 10 months and get 12 (two months free versus paying monthly). Switch between monthly and annual anytime."
 [pfaq4_q]
 other = "Is there a trial period?"
 [pfaq4_a]
-other = "Coming soon. In the meantime, start with the Free tier."
+other = "Yes - every paid plan starts with a 14-day free trial. No charge until it ends, and you can cancel anytime."
 [pfaq5_q]
 other = "What happens if I exceed my plan limits?"
 [pfaq5_a]
@@ -910,7 +910,7 @@ other = "Built with security best practices at every layer."
 [security_infra_binary_title]
 other = "Signed Binaries"
 [security_infra_binary_text]
-other = "All releases signed with Sigstore cosign. SBOM included. Reproducible builds via GoReleaser."
+other = "Linux and macOS binaries (v0.11.4 and later) are signed with Sigstore cosign keyless signatures. Every release ships an SBOM and checksums."
 [security_infra_scanning_title]
 other = "Dependency Scanning"
 [security_infra_scanning_text]
@@ -991,3 +991,17 @@ other = "MCP Tools"
 other = "Условия использования"
 [footer_privacy]
 other = "Политика конфиденциальности"
+
+# ops#142 GDPR portability/erasure callout (security page)
+[security_privacy_title]
+other = "Конфиденциальность и контроль данных"
+[security_privacy_subtitle]
+other = "Ваши данные принадлежат вам - заберите их или удалите, без обращения в поддержку."
+[security_privacy_export_title]
+other = "Самостоятельный экспорт"
+[security_privacy_export_text]
+other = "Клиенты Cloud в любой момент экспортируют всё - рабочие пространства, участников, загрузки, историю оплат - одним файлом. Community Edition хранит ваш контент в формате Markdown в вашем собственном git-репозитории."
+[security_privacy_delete_title]
+other = "Право на удаление"
+[security_privacy_delete_text]
+other = "Удалите свою учётную запись самостоятельно в настройках, с подтверждением паролем. Мы анонимизируем ваши персональные данные, сохраняя целостность аудита, в соответствии с принципом минимизации данных GDPR. (Учётные записи только с SSO: обратитесь в поддержку.)"

--- a/i18n/uk.toml
+++ b/i18n/uk.toml
@@ -198,7 +198,7 @@ other = "Ваша документація зберігається як ста�
 [faq6_q]
 other = "Valoryx підтримує кілька робочих просторів?"
 [faq6_a]
-other = "Так. Плани Team та Business підтримують необмежену кількість робочих просторів, інтеграцію SSO, audit logging та гранулярний контроль доступу на основі ролей."
+other = "Так. Community Edition підтримує необмежену кількість робочих просторів і редакторів. Cloud Free включає 1 робочий простір із 3 редакторами, Team — 3 робочі простори з 15 редакторами, а Business — 10 робочих просторів із 50 редакторами. Кожен робочий простір підключається до власного git-репозиторію з незалежними правами доступу."
 
 [contact_title]
 other = "Зв'язатися з Нами"
@@ -738,7 +738,7 @@ other = "Ask questions, share ideas, and connect with other users."
 [oss_cta_title]
 other = "Need more than Community Edition?"
 [oss_cta_text]
-other = "Valoryx Enterprise adds SSO, advanced analytics, priority support, and unlimited editors."
+other = "Valoryx Enterprise adds SSO/SAML (on request), advanced analytics, priority support, and unlimited editors."
 [oss_cta_btn_pricing]
 other = "View Pricing"
 [oss_cta_btn_contact]
@@ -802,11 +802,11 @@ other = "50 Editors"
 [pb_feat3]
 other = "500 Сторінок на Робочий Простір"
 [pb_feat5]
-other = "SSO / SAML"
+other = "SSO / SAML (coming soon)"
 [pb_feat6]
 other = "Analytics Dashboard"
 [pb_feat7]
-other = "Audit Logs"
+other = "Audit Logs (coming soon)"
 [pricing_community]
 other = "Community Edition"
 [pce_feat1]
@@ -842,11 +842,11 @@ other = "Yes. Since Valoryx is git-native, your content syncs to a git repositor
 [pfaq3_q]
 other = "Do you offer annual billing?"
 [pfaq3_a]
-other = "Coming soon with a 20% discount. Start with monthly billing today."
+other = "Yes - annual billing is live. Pay for 10 months and get 12 (two months free versus paying monthly). Switch between monthly and annual anytime."
 [pfaq4_q]
 other = "Is there a trial period?"
 [pfaq4_a]
-other = "Coming soon. In the meantime, start with the Free tier."
+other = "Yes - every paid plan starts with a 14-day free trial. No charge until it ends, and you can cancel anytime."
 [pfaq5_q]
 other = "What happens if I exceed my plan limits?"
 [pfaq5_a]
@@ -910,7 +910,7 @@ other = "Built with security best practices at every layer."
 [security_infra_binary_title]
 other = "Signed Binaries"
 [security_infra_binary_text]
-other = "All releases signed with Sigstore cosign. SBOM included. Reproducible builds via GoReleaser."
+other = "Linux and macOS binaries (v0.11.4 and later) are signed with Sigstore cosign keyless signatures. Every release ships an SBOM and checksums."
 [security_infra_scanning_title]
 other = "Dependency Scanning"
 [security_infra_scanning_text]
@@ -991,3 +991,17 @@ other = "MCP Tools"
 other = "Умови використання"
 [footer_privacy]
 other = "Політика конфіденційності"
+
+# ops#142 GDPR portability/erasure callout (security page)
+[security_privacy_title]
+other = "Конфіденційність і контроль даних"
+[security_privacy_subtitle]
+other = "Ваші дані належать вам - заберіть їх або видаліть, без звернення до підтримки."
+[security_privacy_export_title]
+other = "Самостійний експорт"
+[security_privacy_export_text]
+other = "Клієнти Cloud будь-коли експортують усе - робочі простори, учасників, завантаження, історію оплат - одним файлом. Community Edition зберігає ваш контент у форматі Markdown у вашому власному git-репозиторії."
+[security_privacy_delete_title]
+other = "Право на видалення"
+[security_privacy_delete_text]
+other = "Видаліть свій обліковий запис самостійно в налаштуваннях, із підтвердженням паролем. Ми знеособлюємо ваші персональні дані, зберігаючи цілісність аудиту, відповідно до принципу мінімізації даних GDPR. (Облікові записи лише з SSO: зверніться до підтримки.)"

--- a/layouts/mcp/list.html
+++ b/layouts/mcp/list.html
@@ -300,7 +300,7 @@ updated within 30 seconds.</code></pre>
   <span style="color: #ffd666;">page</span>       → auth/overview.md (full content)
   <span style="color: #ffd666;">parent</span>     → auth/_index.md
   <span style="color: #ffd666;">children</span>   → auth/oauth.md, auth/api-keys.md
-  <span style="color: #ffd666;">siblings</span>   → auth/sso.md, auth/webauthn.md
+  <span style="color: #ffd666;">siblings</span>   → auth/sessions.md, auth/webauthn.md
   <span style="color: #ffd666;">linked</span>     → getting-started/quickstart.md
   <span style="color: #ffd666;">metadata</span>   → workspace slug, page path, content hash</code></pre>
       </div>

--- a/layouts/open-source/list.html
+++ b/layouts/open-source/list.html
@@ -181,7 +181,7 @@
 <section class="cta-section">
   <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center reveal">
     <h3>{{ i18n "oss_cta_title" | default "Need more than Community Edition?" }}</h3>
-    <p>{{ i18n "oss_cta_text" | default "Valoryx Enterprise adds SSO, advanced analytics, priority support, and unlimited editors." }}</p>
+    <p>{{ i18n "oss_cta_text" | default "Valoryx Enterprise adds SSO/SAML (on request), advanced analytics, priority support, and unlimited editors." }}</p>
     <div class="flex flex-wrap justify-center gap-3">
       <a href="{{ $homeURL }}#pricing" class="cta-btn">{{ i18n "oss_cta_btn_pricing" | default "View Pricing" }}</a>
       <a href="{{ $homeURL }}#contact" class="cta-btn">{{ i18n "oss_cta_btn_contact" | default "Contact Sales" }}</a>

--- a/layouts/partials/sections/pricing.html
+++ b/layouts/partials/sections/pricing.html
@@ -85,8 +85,8 @@
             <li><i class="bi bi-check"></i> {{ i18n "pb_feat1" | default "10 Workspaces" }}</li>
             <li><i class="bi bi-check"></i> {{ i18n "pb_feat2" | default "50 Editors" }}</li>
             <li><i class="bi bi-check"></i> {{ i18n "pb_feat3" | default "500 Pages per Workspace" }}</li>
-            <li><i class="bi bi-check"></i> {{ i18n "pb_feat5" | default "SSO / SAML" }}</li>
-            <li><i class="bi bi-check"></i> {{ i18n "pb_feat7" | default "Audit Logs" }}</li>
+            <li><i class="bi bi-check"></i> {{ i18n "pb_feat5" | default "SSO / SAML (coming soon)" }}</li>
+            <li><i class="bi bi-check"></i> {{ i18n "pb_feat7" | default "Audit Logs (coming soon)" }}</li>
           </ul>
           <a href="#contact" class="buy-btn" aria-label="Get in Touch">{{ i18n "pricing_coming_soon" | default "Coming Soon" }} — {{ i18n "pricing_contact" | default "Get in Touch" }}</a>
           <p class="text-xs mt-3" style="color: var(--muted);">{{ i18n "pricing_enterprise_note" | default "Custom plans available for larger teams" }}</p>

--- a/layouts/pricing/list.html
+++ b/layouts/pricing/list.html
@@ -117,9 +117,9 @@
             <li><i class="bi bi-check"></i> {{ i18n "pb_feat1" | default "10 Workspaces" }}</li>
             <li><i class="bi bi-check"></i> {{ i18n "pb_feat2" | default "50 Editors" }}</li>
             <li><i class="bi bi-check"></i> {{ i18n "pb_feat3" | default "500 Pages per Workspace" }}</li>
-            <li><i class="bi bi-check"></i> {{ i18n "pb_feat5" | default "SSO / SAML" }}</li>
+            <li><i class="bi bi-check"></i> {{ i18n "pb_feat5" | default "SSO / SAML (coming soon)" }}</li>
             <li><i class="bi bi-check"></i> {{ i18n "pb_feat6" | default "Analytics Dashboard" }}</li>
-            <li><i class="bi bi-check"></i> {{ i18n "pb_feat7" | default "Audit Logs" }}</li>
+            <li><i class="bi bi-check"></i> {{ i18n "pb_feat7" | default "Audit Logs (coming soon)" }}</li>
           </ul>
           <div class="mt-auto pt-4">
             <a href="{{ $homeURL }}#contact" class="buy-btn">{{ i18n "pricing_coming_soon" | default "Coming Soon" }} — {{ i18n "pricing_contact" | default "Get in Touch" }}</a>
@@ -173,9 +173,9 @@
           <tr><th scope="row">MCP Server</th><td class="check">&#10003;</td><td class="check">&#10003;</td><td class="valoryx-col check">&#10003;</td><td class="check">&#10003;</td></tr>
           <tr><th scope="row">Custom Domains</th><td class="cross">&#10007;</td><td class="cross">&#10007;</td><td class="valoryx-col check">&#10003;</td><td class="check">&#10003;</td></tr>
           <tr><th scope="row">Priority Support</th><td class="cross">&#10007;</td><td class="cross">&#10007;</td><td class="valoryx-col check">&#10003;</td><td class="check">&#10003;</td></tr>
-          <tr><th scope="row">SSO / SAML</th><td class="cross">&#10007;</td><td class="cross">&#10007;</td><td class="valoryx-col cross">&#10007;</td><td class="check">&#10003;</td></tr>
+          <tr><th scope="row">SSO / SAML</th><td class="cross">&#10007;</td><td class="cross">&#10007;</td><td class="valoryx-col cross">&#10007;</td><td style="color: var(--muted); font-size: 0.85rem; font-weight: 600;">Soon</td></tr>
           <tr><th scope="row">Analytics Dashboard</th><td class="cross">&#10007;</td><td class="cross">&#10007;</td><td class="valoryx-col cross">&#10007;</td><td class="check">&#10003;</td></tr>
-          <tr><th scope="row">Audit Logs</th><td class="cross">&#10007;</td><td class="cross">&#10007;</td><td class="valoryx-col cross">&#10007;</td><td class="check">&#10003;</td></tr>
+          <tr><th scope="row">Audit Logs</th><td class="cross">&#10007;</td><td class="cross">&#10007;</td><td class="valoryx-col cross">&#10007;</td><td style="color: var(--muted); font-size: 0.85rem; font-weight: 600;">Soon</td></tr>
         </tbody>
       </table>
     </div>

--- a/layouts/security/list.html
+++ b/layouts/security/list.html
@@ -79,6 +79,31 @@
   </div>
 </section>
 
+<!-- Privacy & Data Control (ops#142) -->
+<section class="py-20 md:py-28">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+
+    <div class="section-title reveal">
+      <h2>{{ i18n "security_privacy_title" | default "Privacy & Data Control" }}</h2>
+      <p>{{ i18n "security_privacy_subtitle" | default "Your data is yours - take it or delete it, no support ticket required." }}</p>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div class="icon-box reveal reveal-delay-1">
+        <div class="icon"><i class="bi bi-box-arrow-up-right"></i></div>
+        <h4>{{ i18n "security_privacy_export_title" | default "Self-Service Export" }}</h4>
+        <p>{{ i18n "security_privacy_export_text" | default "Cloud customers export everything - workspaces, members, uploads, billing history - as a single download, anytime. Community Edition keeps your content as Markdown in your own git repository." }}</p>
+      </div>
+      <div class="icon-box reveal reveal-delay-2">
+        <div class="icon"><i class="bi bi-trash3"></i></div>
+        <h4>{{ i18n "security_privacy_delete_title" | default "Right to Erasure" }}</h4>
+        <p>{{ i18n "security_privacy_delete_text" | default "Delete your account yourself from settings, password-confirmed. We anonymize your personal data while preserving audit integrity, in line with GDPR data minimization. (SSO-only accounts: contact support.)" }}</p>
+      </div>
+    </div>
+
+  </div>
+</section>
+
 <!-- Infrastructure -->
 <section class="py-20 md:py-28">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -92,7 +117,7 @@
       <div class="icon-box reveal reveal-delay-1">
         <div class="icon"><i class="bi bi-shield-check"></i></div>
         <h4>{{ i18n "security_infra_binary_title" | default "Signed Binaries" }}</h4>
-        <p>{{ i18n "security_infra_binary_text" | default "All releases are signed with Sigstore cosign. SBOM (Software Bill of Materials) included with every release. Reproducible builds via GoReleaser." }}</p>
+        <p>{{ i18n "security_infra_binary_text" | default "Linux and macOS binaries (v0.11.4 and later) are signed with Sigstore cosign keyless signatures. Every release ships an SBOM and checksums." }}</p>
       </div>
       <div class="icon-box reveal reveal-delay-2">
         <div class="icon"><i class="bi bi-bug"></i></div>


### PR DESCRIPTION
## Why
Pre-paid-launch truth pass on valoryx.org (C-site stream, ops#306). Four growth handoffs flagged marketing claims drifting from shipped v0.11.6 reality: **#130** (pricing FAQ says trial/annual are "coming soon" — both are LIVE), **#200** (SSO/SAML advertised as a paid feature — zero code exists), **#181** (security page claims "All releases signed" — older + Windows binaries are not), **#142** (security page omits the GDPR export/self-delete differentiator). Every claim below was grep-verified against `product/docplatform` code **this session** (citations in Verification Log). The #200 drop-vs-coming-soon call was put to the owner, who chose **coming-soon (Option B)**.

## Approach
11 files, all in the growth domain (`i18n/`, `layouts/`), ×6 locales together:
- **i18n/{en,de,es,fr,ru,uk}.toml** — `pfaq4_a` (trial→live), `pfaq3_a` (annual→live, "2 months free" not the wrong "20%"), `oss_cta_text` + `pb_feat5` (SSO→coming-soon/on-request), `pb_feat7` (Audit Logs→coming-soon), `security_infra_binary_text` (signed claim→accurate), `faq6_a` non-EN (drop SSO + false "unlimited workspaces", mirror EN's true plan-limits answer), and 6 new `security_privacy_*` keys (GDPR callout, translated).
- **layouts/pricing/list.html** — `pb_feat5`/`pb_feat7` defaults + the SSO and Audit-Logs **comparison-table** Business cells flipped from ✓ to "Soon".
- **layouts/partials/sections/pricing.html** — homepage pricing `pb_feat5`/`pb_feat7` defaults.
- **layouts/open-source/list.html** — `oss_cta_text` default.
- **layouts/mcp/list.html** — illustrative `auth/sso.md`→`auth/sessions.md` in the MCP mockup (no SSO docs exist).
- **layouts/security/list.html** — fixed the signed-binaries default + added a "Privacy & Data Control" section (self-service export + right-to-erasure).

**Parallel finding fixed for consistency:** "Audit Logs" was advertised as a Business feature but is **not** a customer feature (no audit endpoint; E.3 customer-audit tab is an unbuilt gap). Given the owner's coming-soon choice for the analogous SSO case + the site's house rule ("features not yet available are labeled accordingly"), it received the same coming-soon treatment on the pricing surfaces I was already editing. Flagged below for owner re-confirm.

## Alternatives Considered
- **#200 drop (Option A)** vs **coming-soon (Option B)** — owner chose B (preserves an enterprise signal honestly). Either was acceptable; the generic "Contact us for Enterprise pricing" CTA survives both.
- **Blog gitbook-vs-valoryx SSO line** (named in #200): the blog carries *systemic* per-locale errors beyond SSO (per-workspace pricing, wrong editor counts, SLA, dedicated-infra, audit-logs). Fixing only SSO would leave grosser lies on the same lines; a full ×6 accuracy pass would unbalance this i18n PR. **Deferred to ops#314**, which folds in the #200 blog sub-item.
- **Audit-logs**: drop entirely vs coming-soon label — chose coming-soon to match the SSO pattern + house rule (reversible).

## Self-Identified Risks
- **Audit-logs labeling is a house-rule inference, not an explicit owner decision** — owner may prefer to drop it instead. Easily reversed; non-blocking. (SSO *was* owner-decided.)
- **#200 not 100% closed by this PR** — its blog sub-item moves to ops#314; the pricing/enterprise/FAQ SSO surfaces ARE fixed here. Recommend keeping #200 open until #314 lands, or closing with a pointer.
- **#181 install pill "Signed and Verified"** left as-is — now substantively true (latest Linux/macOS binaries are cosign-signed + checksums verify); the precise, version-qualified statement lives in the security section.
- i18n line-ending warnings on commit are benign Windows autocrlf (diff is +159/−50, not a full-file rewrite).
- No product/code/other-domain files touched. Blog untouched (no blog locale drift introduced).

## Verification Log
- **Compile/Build:** `hugo --minify` → **PASS** (exit 0), all 6 languages (EN 110 / others 108 pages), after `npm ci` in the fresh worktree (Tailwind CLI).
- **i18n parity:** `validate-sources.sh` → **474 keys complete in all 6 locales**; per-key `^\[..\]` diff EN vs each locale = no drift. New `security_privacy_*` keys present ×6.
- **Rendered output:** grep of `public/` → **zero** residual "20% discount" / "All releases signed" / bare `>SSO / SAML</td>`; qualified strings + #142 callout (incl. translated `Datenschutz & Datenkontrolle` / `Recht auf Löschung`) all render.
- **#130 trial:** `internal/config/config.go:265` `envOrDefault("TRIAL_DURATION_DAYS","14")` (comment :82 "default 14"); `internal/billing/service.go:160-163` wires `TrialPeriodDays` into Stripe checkout when >0. **Prod env checked (read-only):** unit `EnvironmentFile=/opt/docplatform/config/.env`, effective proc env has **no** TRIAL override → default 14 is live.
- **#130 annual = "2 months free", NOT "20%":** `internal/db/migrations/001_initial.sql:693` (team `price_monthly=2900`, `price_annual=29000`) + `:698` (business `7900`/`79000`) → annual = 10× monthly = 2 months free (~16.7%, so the old "20% discount" copy was itself inaccurate). `internal/domain/types.go:742-767` `PriceAnnual` + `BillingInterval` (monthly/annual).
- **#200 SSO absence:** `grep -rniE "saml|single-sign-on" --include=*.go internal/ cmd/` → **0** implementations (only an OIDC-account guard in `portability_delete.go:176` + a label string in `auth/service.go:979`).
- **#181 cosign:** `.github/workflows/release.yml:165-181` cosign v2.6.3 keyless. Release assets: **v0.11.4/v0.11.5/v0.11.6 = 4 `.sig` each (Linux+macOS amd64/arm64) + SBOM + checksums.txt; v0.10.0/v0.9.0 = 0 `.sig`; Windows `.exe` has no `.sig`** (cosign covers Linux/macOS only; Authenticode gap = ops#274).
- **#142 export/delete:** `internal/api/handlers/portability.go:85` (`ExportOrg`), `:153` (`ExportUserSelf`), `portability_delete.go` self-delete (password-gated; SSO-only-account caveat at `:176`). Copy respects constraints: cloud-only, no "exactly 1/24h" SLA, OIDC-only accounts qualified.
- **Audit-logs absence:** `001_initial.sql:698` business `features` json has **no** audit key; no customer audit endpoint (only admin/platform); PRODUCT-MEMORY §7 lists "customer-facing audit tab (E.3)" as an unbuilt gap.
- **Callers traced:** `pb_feat5`/`pb_feat7`/`oss_cta_text`/`security_infra_binary_text` — all usages (i18n value + layout `| default` fallbacks) updated together; comparison-table rows are hardcoded (shared across locales).
- **Coverage / API-UI:** N/A (marketing content only; no handlers changed).
- **Unverified:** live prod `plans` table values (used the build-time seed `001_initial.sql`; migrations don't alter prices — only #534/034 page caps).

## Context Snapshot
---
agent: growth-agent
session_started: 2026-06-14T00:00:00Z
last_updated: 2026-06-14T01:30:00Z
north_star: C-site stream (ops#306 launch push) — make every valoryx.org marketing claim match shipped v0.11.6 reality before paid launch; close ops#130/#200/#181/#142 via ONE site PR ×6 locales. Teammate — stop at PR open + gate handoff on ops#306; no merge, no STATE.md.
current_task: Edits + clean hugo build done; opening PR on Valoryx-org/valoryx.org then filing gate handoff on ops#306.
next_action: gh pr create (branch growth/site-truth-pass) with PR-BODY-TEMPLATE → file review-gate handoff on ops#306 (label review-requested,build-agent) → STOP (teammate; lead merges).
status: active
---

## Decisions & Why
- **#200 SSO — owner chose Option B (label coming-soon/on-request)** via AskUserQuestion 2026-06-14. Verified ZERO SSO/SAML code in product/docplatform. Qualified across i18n (pb_feat5, oss_cta_text ×6), layouts (pricing/list, partials/sections/pricing, open-source defaults), comparison-table Business cell ✓→"Soon", faq6_a non-EN (dropped SSO + false "unlimited workspaces", mirrored EN plan-limits answer), mcp mockup auth/sso.md→auth/sessions.md.
- **#130 trial+annual LIVE**: pfaq4_a "coming soon"→14-day trial live (config.go:265 default 14, prod no override, billing service.go:160). pfaq3_a "20% discount"→**2 months free** (annual=10× monthly per 001_initial.sql:693/698; "20%" was itself WRONG = actually ~16.7%). ×6.
- **#181 signed**: en.toml security_infra_binary_text + layout default "All releases signed"→"Linux and macOS binaries (v0.11.4+) signed with cosign; SBOM+checksums" (v0.10.0/v0.9.0=0 .sig; Windows not cosign-signed). ×6.
- **#142 export/delete**: new "Privacy & Data Control" section in security layout + 6 i18n keys (security_privacy_*) translated ×6. Cloud-only; SSO-only-account caveat; no "exactly 1/24h" promise.
- **AUDIT-LOGS parallel over-claim**: pb_feat7 + comparison row claim "Audit Logs" as Business feature; NOT a customer feature (no audit endpoint; E.3 gap). Applied SAME coming-soon house-rule fix as SSO on pricing surfaces (pb_feat7 ×6 + 2 layout defaults + comparison cell→"Soon"). Flagged for owner confirm in PR.
- **BLOG EXCLUDED → ops#314 filed**: gitbook-vs-valoryx.md ×6 has systemic per-workspace-pricing + editor-count + SLA/dedicated-infra/audit/SSO errors that differ per locale; a fuller ×6 accuracy pass would unbalance this i18n PR. #200 blog SSO sub-item folds into #314.

## Files Touched This Session (worktree growth/site-truth-pass, 11 files)
- i18n/{en,de,es,fr,ru,uk}.toml — pfaq3_a, pfaq4_a, oss_cta_text, pb_feat5, pb_feat7, security_infra_binary_text, faq6_a (non-EN), +6 new security_privacy_* keys. DONE.
- layouts/pricing/list.html — pb_feat5/pb_feat7 defaults + SSO & Audit-Logs comparison rows→"Soon". DONE.
- layouts/partials/sections/pricing.html — pb_feat5/pb_feat7 defaults. DONE.
- layouts/open-source/list.html — oss_cta_text default. DONE.
- layouts/mcp/list.html — auth/sso.md→auth/sessions.md. DONE.
- layouts/security/list.html — signed default fix + new Privacy & Data Control section. DONE.

## Open Artifacts
- Branch: growth/site-truth-pass (from origin/main c400ce1). Stream claimed ops#306; issues claimed #130/#200/#181/#142.
- Issue filed: ops#314 (blog accuracy follow-up).
- PR: about to open on Valoryx-org/valoryx.org.
- Build: hugo --minify exit 0, all 6 langs (110/108 pages); i18n parity 474/474 all locales; no over-claim survives in public/.

## Blocking Questions
- None (SSO owner decision resolved). Audit-logs coming-soon labeling = house-rule inference, flagged for owner re-confirm in PR (non-blocking).

## Do-Not-Lose
- Annual = 10× monthly = 2 months free, NOT 20% (001_initial.sql:693/698). Windows NOT cosign-signed. Prod no TRIAL override.
- Validator warnings (5-editors in agent logs, STATE.md phantom ref) are PRE-EXISTING non-site files, not this PR.

## Resume Hints
- If PR not open: cd worktrees/site-truth-pass; commit (11 files); gh pr create --body-file with .workspace/PR-BODY-TEMPLATE.md.
- Then: gh issue comment 306 with gate handoff (label review-requested,build-agent). STOP — do not merge, do not touch STATE.md.

## Linked
- Handoffs (this PR): https://github.com/Valoryx-org/issues/issues/130 · /200 · /181 · /142
- Coordination: https://github.com/Valoryx-org/issues/issues/306 (C-site stream)
- Follow-up filed: https://github.com/Valoryx-org/issues/issues/314 (gitbook-vs blog accuracy ×6 — folds in #200 blog SSO sub-item)
- Prompt: `.workspace/PROMPT-GROWTH-SITE-TRUTH.md`
