### PR TITLE
fix(seo): repair multilingual sitemap — robots points at a sitemapindex (all 6 langs)

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -55,12 +55,26 @@ disableHugoGeneratorInject      = true
 [build]
   noJSConfigInAssets = true
 
+# Sitemap is a HOME-kind output only. Attaching it to `section` made every section
+# render a sitemap that collided at the language-root sitemap.xml path (last writer won,
+# clobbering the complete home sitemap down to a single URL). SitemapIndex (custom format
+# below) renders the multilingual index that robots.txt advertises.
 [outputs]
-  home     = ["HTML", "RSS", "Sitemap"]
-  section  = ["HTML", "RSS", "Sitemap"]
+  home     = ["HTML", "RSS", "Sitemap", "SitemapIndex"]
+  section  = ["HTML", "RSS"]
   page     = ["HTML"]
   taxonomy = ["HTML"]
   term     = ["HTML"]
+
+# Multilingual sitemap index: one <sitemapindex> listing every language's sitemap.
+# Rendered by layouts/_default/sitemapindex.xml; robots.txt points search engines here.
+[outputFormats.SitemapIndex]
+  mediaType   = "application/xml"
+  baseName    = "sitemapindex"
+  isHTML      = false
+  isPlainText = true
+  noUgly      = true
+  rel         = "sitemap"
 
 [taxonomies]
 

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,0 +1,41 @@
+{{- /*
+  Multilingual sitemap (per language).
+
+  Overrides Hugo's internal sitemap template for one reason: with
+  defaultContentLanguageInSubdir=false the default language has TWO home nodes —
+  the site-root home (published at /) and the language home (at /en/). The
+  site-root home's `.Pages` enumerates only the top-level section indexes, so the
+  stock template renders an INCOMPLETE root /sitemap.xml (sections only) while the
+  full URL set lands at /en/sitemap.xml. robots.txt -> sitemapindex.xml -> this
+  file must be complete for every language, so we range over `site.Pages` (the
+  whole current-language page set) instead of the home node's `.Pages`.
+
+  hreflang <xhtml:link> alternates mirror Hugo's internal template exactly:
+  each translation in language order, then a self-reference last.
+*/ -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{- range site.Pages }}
+    {{- if .Permalink }}
+  <url>
+    <loc>{{ .Permalink }}</loc>
+    {{- if not .Lastmod.IsZero }}
+    <lastmod>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</lastmod>
+    {{- end }}
+    {{- with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>
+    {{- end }}
+    {{- if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>
+    {{- end }}
+    {{- if .IsTranslated }}
+      {{- range .Translations }}
+    <xhtml:link rel="alternate" hreflang="{{ .Language.LanguageCode }}" href="{{ .Permalink }}" />
+      {{- end }}
+    <xhtml:link rel="alternate" hreflang="{{ .Language.LanguageCode }}" href="{{ .Permalink }}" />
+    {{- end }}
+  </url>
+    {{- end }}
+  {{- end }}
+</urlset>

--- a/layouts/_default/sitemapindex.xml
+++ b/layouts/_default/sitemapindex.xml
@@ -1,0 +1,10 @@
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{{- range .Sites }}
+{{- with .Home.OutputFormats.Get "sitemap" }}
+  <sitemap>
+    <loc>{{ .Permalink }}</loc>
+  </sitemap>
+{{- end }}
+{{- end }}
+</sitemapindex>

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -29,7 +29,7 @@ Disallow: /
 User-agent: Amazonbot
 Disallow: /
 
-Sitemap: {{ "sitemap.xml" | absURL }}
+Sitemap: {{ "sitemapindex.xml" | absURL }}
 
 # AI agent discovery
 Allow: /llms.txt


### PR DESCRIPTION
## Problem

The multilingual sitemap was broken across all 6 languages, silently suppressing search-engine
crawling of the whole site. Rendered from `main` before this change:

```
robots.txt  ->  Sitemap: https://valoryx.org/sitemap.xml

./sitemap.xml         loc=1     <-- robots points here: only /vs/gitbook/
./en/sitemap.xml      loc=68    <-- full EN set, orphaned at /en/ (nothing links to it)
./fr/sitemap.xml      loc=1
./de/sitemap.xml      loc=1
./es/sitemap.xml      loc=1
./ru/sitemap.xml      loc=1
./uk/sitemap.xml      loc=1
```

Search engines were told the site has **1 URL**.

### Root cause

1. The `Sitemap` output format was attached to **both `home` and `section`** in `[outputs]`.
   Section-level sitemaps collided at the language-root `sitemap.xml` path; the last writer (the
   single-page `vs` section) won and clobbered each complete home sitemap down to one URL.
2. There was **no sitemap index**, so the per-language sitemaps were unreferenced.
3. With `defaultContentLanguageInSubdir = false`, the default language has two home nodes — the
   site-root home (published at `/`) and the language home (`/en/`). The site-root home's `.Pages`
   enumerates only top-level section indexes, so even after (1) the root `/sitemap.xml` was
   incomplete (13 of 67 URLs).

## Fix

- **`Sitemap` is now a `home`-kind output only** — ends the section collision.
- **New `SitemapIndex` output format + `layouts/_default/sitemapindex.xml`** enumerate every
  language's sitemap from `.Sites`. It auto-scales: add a 7th language and it appears in the index
  with no template change.
- **`robots.txt` points at `/sitemapindex.xml`**, so all 6 per-language sitemaps are discoverable.
- **`layouts/_default/sitemap.xml` override** ranges over `site.Pages` (the whole current-language
  page set) instead of the home node's `.Pages`, so every language's sitemap lists all of its real
  rendered pages. `hreflang` `<xhtml:link>` alternates are preserved exactly (each translation in
  language order, then a self-reference).

## Proof (rendered from this branch)

```
robots.txt  ->  Sitemap: https://valoryx.org/sitemapindex.xml

sitemapindex.xml   <sitemapindex> with 6 <sitemap> entries:
  https://valoryx.org/sitemap.xml      (en)
  https://valoryx.org/fr/sitemap.xml
  https://valoryx.org/de/sitemap.xml
  https://valoryx.org/es/sitemap.xml
  https://valoryx.org/ru/sitemap.xml
  https://valoryx.org/uk/sitemap.xml

./sitemap.xml      <urlset> loc=67   (== the full EN set, verified identical)
./fr/sitemap.xml   <urlset> loc=67
./de/sitemap.xml   <urlset> loc=67
./es/sitemap.xml   <urlset> loc=67
./ru/sitemap.xml   <urlset> loc=67
./uk/sitemap.xml   <urlset> loc=67
```

- **Discoverable URLs: 1 → 402** (6 × 67).
- Every URL maps to a **real, non-alias rendered HTML page** (verified: 67 real `index.html` per
  language tree, 0 alias redirects; spot-checked fallback pages render real translated content).
- **All 8 sitemap files validate as well-formed XML** (parsed with a real XML parser).
- `hreflang` alternates unchanged — no SEO regression.

Built with `hugo --gc --minify` (Hugo 0.157.0 extended), Tailwind CLI pipeline intact.

## Scope / notes

Site templates + config only (4 files). No content, styling, or product changes. Does not address
the separate observation that all 6 languages render full 67-page trees (i.e. untranslated pages
fall back and are served per-language) — that is existing behavior and correct to include in the
sitemaps; flagged for the record, not changed here.
