### PR TITLE
chore: retrigger CF Pages deploy — site version.json stuck at 0.11.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+
+<!-- CF Pages build for f894e77 failed (infra); this commit retriggers the v0.12.0 site deploy — 2026-07-02 -->


### PR DESCRIPTION
The Cloudflare Pages build for f894e77 ("release: bump version to v0.12.0") failed on CF infra on 2026-06-23 and was never retried — the live site still serves `/api/version.json` = 0.11.8 while main carries 0.12.0. Local `npm ci && hugo` builds clean across all 6 locales, so a fresh push-triggered build should deploy the pending bump.

This PR is a no-op README comment purely to produce a new commit on main → new Pages build.

Verification after merge: `curl -s https://valoryx.org/api/version.json` → `"latest": "0.12.0"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
