### PR TITLE
fix(install): remove commands that cannot work + a signing claim that is not true (ops#457)

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -488,7 +488,7 @@ other = "Quick Start"
 [install_quickstart_comment1]
 other = "Start the server"
 [install_quickstart_running]
-other = "Open http://localhost:3000"
+other = "Open http://localhost:3000 and register - your first account gets its own workspace"
 [install_quickstart_comment2]
 other = "Initialize a workspace with a git repo"
 [install_win_comment1]
@@ -520,7 +520,7 @@ other = "Single Binary"
 [install_pill_free]
 other = "Free Forever"
 [install_pill_signed]
-other = "Signed and Verified"
+other = "Checksums Published"
 [install_verify_title]
 other = "You are all set!"
 [install_trouble_title]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -516,7 +516,7 @@ other = "Quick Start"
 [install_quickstart_comment1]
 other = "Start the server"
 [install_quickstart_running]
-other = "Open http://localhost:3000"
+other = "Open http://localhost:3000 and register - your first account gets its own workspace"
 [install_quickstart_comment2]
 other = "Initialize a workspace with a git repo"
 [install_win_comment1]
@@ -548,7 +548,7 @@ other = "Single Binary"
 [install_pill_free]
 other = "Free Forever"
 [install_pill_signed]
-other = "Signed and Verified"
+other = "Checksums Published"
 [install_verify_title]
 other = "You are all set!"
 [install_trouble_title]

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -488,7 +488,7 @@ other = "Quick Start"
 [install_quickstart_comment1]
 other = "Start the server"
 [install_quickstart_running]
-other = "Open http://localhost:3000"
+other = "Open http://localhost:3000 and register - your first account gets its own workspace"
 [install_quickstart_comment2]
 other = "Initialize a workspace with a git repo"
 [install_win_comment1]
@@ -520,7 +520,7 @@ other = "Single Binary"
 [install_pill_free]
 other = "Free Forever"
 [install_pill_signed]
-other = "Signed and Verified"
+other = "Checksums Published"
 [install_verify_title]
 other = "You are all set!"
 [install_trouble_title]

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -488,7 +488,7 @@ other = "Quick Start"
 [install_quickstart_comment1]
 other = "Start the server"
 [install_quickstart_running]
-other = "Open http://localhost:3000"
+other = "Open http://localhost:3000 and register - your first account gets its own workspace"
 [install_quickstart_comment2]
 other = "Initialize a workspace with a git repo"
 [install_win_comment1]
@@ -520,7 +520,7 @@ other = "Single Binary"
 [install_pill_free]
 other = "Free Forever"
 [install_pill_signed]
-other = "Signed and Verified"
+other = "Checksums Published"
 [install_verify_title]
 other = "You are all set!"
 [install_trouble_title]

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -488,7 +488,7 @@ other = "Quick Start"
 [install_quickstart_comment1]
 other = "Start the server"
 [install_quickstart_running]
-other = "Open http://localhost:3000"
+other = "Open http://localhost:3000 and register - your first account gets its own workspace"
 [install_quickstart_comment2]
 other = "Initialize a workspace with a git repo"
 [install_win_comment1]
@@ -520,7 +520,7 @@ other = "Single Binary"
 [install_pill_free]
 other = "Free Forever"
 [install_pill_signed]
-other = "Signed and Verified"
+other = "Checksums Published"
 [install_verify_title]
 other = "You are all set!"
 [install_trouble_title]

--- a/i18n/uk.toml
+++ b/i18n/uk.toml
@@ -488,7 +488,7 @@ other = "Quick Start"
 [install_quickstart_comment1]
 other = "Start the server"
 [install_quickstart_running]
-other = "Open http://localhost:3000"
+other = "Open http://localhost:3000 and register - your first account gets its own workspace"
 [install_quickstart_comment2]
 other = "Initialize a workspace with a git repo"
 [install_win_comment1]
@@ -520,7 +520,7 @@ other = "Single Binary"
 [install_pill_free]
 other = "Free Forever"
 [install_pill_signed]
-other = "Signed and Verified"
+other = "Checksums Published"
 [install_verify_title]
 other = "You are all set!"
 [install_trouble_title]

--- a/layouts/install/list.html
+++ b/layouts/install/list.html
@@ -89,11 +89,7 @@
               <div><span class="prompt">$</span> <span class="cmd">{{ $bin }} serve</span>
                 <button onclick="copyCmd('{{ $bin }} serve', this)" class="ml-3 opacity-50 hover:opacity-100 transition-opacity" title="{{ i18n "download_copy" | default "Copy" }}"><i class="bi bi-clipboard"></i></button>
               </div>
-              <div class="mt-1"><span class="success">{{ i18n "install_quickstart_running" | default "Open http://localhost:3000" }}</span></div>
-              <div class="mt-2"><span class="comment"># {{ i18n "install_quickstart_comment2" | default "Initialize a workspace with a git repo" }}</span></div>
-              <div><span class="prompt">$</span> <span class="cmd">{{ $bin }} init --repo https://github.com/your-org/docs.git</span>
-                <button onclick="copyCmd('{{ $bin }} init --repo https://github.com/your-org/docs.git', this)" class="ml-3 opacity-50 hover:opacity-100 transition-opacity" title="{{ i18n "download_copy" | default "Copy" }}"><i class="bi bi-clipboard"></i></button>
-              </div>
+              <div class="mt-1"><span class="success">{{ i18n "install_quickstart_running" | default "Open http://localhost:3000 and register — your first account gets its own workspace" }}</span></div>
             </div>
           </div>
         </div>
@@ -113,10 +109,6 @@
             <div><span class="prompt">PS&gt;</span> <span class="cmd">Invoke-WebRequest -Uri "{{ $latest }}/{{ $bin }}-windows-amd64.exe" -OutFile "{{ $bin }}.exe"</span>
               <button onclick="copyCmd('Invoke-WebRequest -Uri &quot;{{ $latest }}/{{ $bin }}-windows-amd64.exe&quot; -OutFile &quot;{{ $bin }}.exe&quot;', this)" class="ml-3 opacity-50 hover:opacity-100 transition-opacity" title="{{ i18n "download_copy" | default "Copy" }}"><i class="bi bi-clipboard"></i></button>
             </div>
-            <div class="mt-2"><span class="comment"># {{ i18n "install_win_comment2" | default "Optional: move to a directory in your PATH" }}</span></div>
-            <div><span class="prompt">PS&gt;</span> <span class="cmd">Move-Item {{ $bin }}.exe "$env:LOCALAPPDATA\Microsoft\WindowsApps\"</span>
-              <button onclick="copyCmd('Move-Item {{ $bin }}.exe &quot;$env:LOCALAPPDATA\\Microsoft\\WindowsApps\\&quot;', this)" class="ml-3 opacity-50 hover:opacity-100 transition-opacity" title="{{ i18n "download_copy" | default "Copy" }}"><i class="bi bi-clipboard"></i></button>
-            </div>
           </div>
         </div>
 
@@ -134,11 +126,7 @@
               <div><span class="prompt">PS&gt;</span> <span class="cmd">.\{{ $bin }}.exe serve</span>
                 <button onclick="copyCmd('.\\{{ $bin }}.exe serve', this)" class="ml-3 opacity-50 hover:opacity-100 transition-opacity" title="{{ i18n "download_copy" | default "Copy" }}"><i class="bi bi-clipboard"></i></button>
               </div>
-              <div class="mt-1"><span class="success">{{ i18n "install_quickstart_running" | default "Open http://localhost:3000" }}</span></div>
-              <div class="mt-2"><span class="comment"># {{ i18n "install_quickstart_comment2" | default "Initialize a workspace with a git repo" }}</span></div>
-              <div><span class="prompt">PS&gt;</span> <span class="cmd">.\{{ $bin }}.exe init --repo https://github.com/your-org/docs.git</span>
-                <button onclick="copyCmd('.\\{{ $bin }}.exe init --repo https://github.com/your-org/docs.git', this)" class="ml-3 opacity-50 hover:opacity-100 transition-opacity" title="{{ i18n "download_copy" | default "Copy" }}"><i class="bi bi-clipboard"></i></button>
-              </div>
+              <div class="mt-1"><span class="success">{{ i18n "install_quickstart_running" | default "Open http://localhost:3000 and register — your first account gets its own workspace" }}</span></div>
             </div>
           </div>
           <div class="flex flex-wrap gap-3 mt-4">
@@ -240,7 +228,7 @@
         <span class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full text-xs font-semibold" style="background: rgba(5,150,82,0.08); color: var(--success);"><i class="bi bi-check-circle-fill"></i> {{ i18n "install_pill_no_deps" | default "Zero Dependencies" }}</span>
         <span class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full text-xs font-semibold" style="background: rgba(5,150,82,0.08); color: var(--success);"><i class="bi bi-check-circle-fill"></i> {{ i18n "install_pill_single" | default "Single Binary" }}</span>
         <span class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full text-xs font-semibold" style="background: rgba(5,150,82,0.08); color: var(--success);"><i class="bi bi-check-circle-fill"></i> {{ i18n "install_pill_free" | default "Free Forever" }}</span>
-        <span class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full text-xs font-semibold" style="background: rgba(5,150,82,0.08); color: var(--success);"><i class="bi bi-check-circle-fill"></i> {{ i18n "install_pill_signed" | default "Signed & Verified" }}</span>
+        <span class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full text-xs font-semibold" style="background: rgba(5,150,82,0.08); color: var(--success);"><i class="bi bi-check-circle-fill"></i> {{ i18n "install_pill_signed" | default "Checksums Published" }}</span>
       </div>
     </div>
 


### PR DESCRIPTION
## Why

Every copy-paste path in the Quick Start blocks on the live install page fails today. Verified against `https://valoryx.org/install/` and product source on 2026-08-20. This is the top of the acquisition funnel and UAT is imminent.

**Cross-domain authorization.** `site/valoryx.org/**` is growth-agent's domain. Opened under the owner's standing authorization on board ops#715 for **ops#457**, verbatim:

> **ops#457** `M` `cross-domain` — Install page ships broken copy-paste commands + a false "Signed" badge. Fix the **factual/technical falsehoods only** — commands that error, wrong versions, false claims. Brand voice and marketing prose stay untouched.

and the owner's direction in this session, verbatim: *"run full review of all we have locally and deployed / improve fix all you find that need fix"*.

Scope held to factual correctness. No voice, headline, CTA, narrative or layout changes.

## Approach

**1. `docplatform init` removed from both Quick Start blocks (bash + PowerShell).**

The page shipped `init --repo <url>`. `--repo` does not exist — the real flags are `--git-url`, plus required `--workspace-name` and `--slug` (`cmd/server/main.go:1229-1232`). But fixing the flag was **not sufficient**: `init` cannot succeed on any database.

```
$ docplatform init --workspace-name "My Docs" --slug my-docs
Error: create workspace: workspace.Create: db.WithTx: add member:
       db.Workspaces.AddMember: constraint failed: FOREIGN KEY constraint failed (787)
```

`cmd/server/main.go:1124` passes the literal actor `"system"` into `CreateWorkspace`, and `workspace_members.user_id TEXT NOT NULL REFERENCES users(id)` (`001_initial.sql:140`). No user with id `"system"` ever exists, so the member insert always violates the FK — and because it runs inside `WithTx`, the workspace insert rolls back with it. Filed as **ops#739 (P1)**.

Publishing a *syntactically* correct command that still errors would move the failure, not remove it. The page now routes users through `serve` → register, which is the flow that works and the one `docplatform-docs` already documents (ops#242).

**2. Windows "Optional: move to your PATH" step removed.**

It ran `Move-Item` on the binary; the very next block ran `.\docplatform.exe serve` from the old location → *"not recognized"*. ops#457 sanctions either making the two blocks consistent or dropping the optional move; dropping it leaves every remaining command correct for every user, including those who skipped it.

**3. `"Signed & Verified"` → `"Checksums Published"`** (template default + all 6 locales).

The pill is global across all four downloads. Against the actual v0.17.1 asset list, `.sig`/`.pem` ship for `linux-amd64/arm64` and `darwin-amd64/arm64` **only** — `docplatform-windows-amd64.exe` has neither a cosign signature nor Authenticode (ops#108/#274). `checksums.txt` is the only claim true for every artifact. Telling a Windows user "Signed" and then having SmartScreen say *"Windows protected your PC"* destroys trust at exactly the wrong moment.

## Alternatives Considered

- **Fix the flag, keep `init`.** Rejected — the command fails regardless of flags.
- **Fix the `"system"` actor bug and keep `init` on the page.** Rejected for *this* PR: it is a Go change to workspace/membership creation, belongs in `docplatform` behind the review gate, and must not be bundled into a site PR. Filed as ops#739; the page can regain `init` once it works.
- **`"Checksum + cosign verified"` for the pill.** Rejected — still false on Windows, which has no `.sig`. Replacing one false claim with a narrower false claim is not a fix.
- **Remove the Docker tab.** Rejected — and my first reason for considering it was **wrong**. I recorded the ghcr command as broken because `curl .../tags/list` returned 401. That test was invalid: the Docker Registry v2 protocol requires a bearer token even for anonymous pulls. With the anonymous token any client (including `docker pull`) fetches automatically, both manifest and tag list return **200**. The package IS public and the Docker command works. ops#457's Docker item is already resolved — no page change needed.

## Self-Identified Risks

- **Cross-domain edit.** Touches growth-agent's `layouts/` and `i18n/`. Mitigated by holding to factual corrections and quoting the authorization, but a growth reviewer should still confirm the replacement pill wording. `"Checksums Published"` is deliberately plain; different phrasing for the same *true* claim is a fine follow-up.
- **Content removal, not just correction.** Two instruction blocks are deleted, shortening the Quick Start. Correct outcome (both were non-functional) but a visible change to the page's shape, and reasonable people could prefer replacing over removing.
- **i18n parity.** `install_pill_signed` and `install_quickstart_running` were already English in all six locale files and remain English. No locale gained or lost a key, but this does not *improve* translation coverage — a translator pass is still owed.
- **Em dash** in the new quickstart string renders in all six locales (verified); if house style prefers ASCII punctuation it is a one-character change.
- **This PR does not fix ops#739.** The install page stops advertising a broken command; the broken command is still broken.

## Verification Log

- `--repo` is not a real flag — `cmd/server/main.go:1229-1232` defines `--git-url`, `--branch`, `--workspace-name`, `--slug`, `--data-dir`. No `--repo`.
- Live page shipped it — `curl -s https://valoryx.org/install/` → `docplatform init --repo https://github.com/your-org/docs.git`, at 2 render sites.
- Old command errors — ran the real binary: `Error: unknown flag: --repo` + usage dump.
- **Corrected command ALSO fails** — 3/3 on fresh data dirs: `FOREIGN KEY constraint failed (787)`; `SELECT COUNT(*) FROM users` → `0`, `FROM workspaces` → `0`.
- Windows self-break — `Move-Item` at old `list.html:117`, then `.\docplatform.exe serve` at old `list.html:139`.
- Signing claim false on Windows — `gh release view v0.17.1 -R Valoryx-org/releases`: `.sig`/`.pem` present for the 4 linux/darwin binaries, **absent** for `docplatform-windows-amd64.exe`.
- ghcr IS public — anonymous bearer token → manifest `200`, tags/list `200`.
- Build — `hugo --gc --minify` (v0.157.0 extended), **0 ERROR lines**. The local build was impossible before this session: `C:\Program Files\nodejs` was on PATH but empty, so the Tailwind transform failed. Installed Node LTS 24.19.0 to make local verification possible at all.
- Rendered output, all 6 locales (en/de/es/fr/ru/uk): `init --` → **0**, `Move-Item` → **0**, `"Signed and Verified"` → **0**, `"Checksums Published"` → present, quickstart line updated.
- Copy-button safety — attribute stays well-formed: `onclick="copyCmd('docplatform … ',this)"` using `&#34;` entities, no stray `"` terminating the attribute.
- Diff hygiene — the first write flipped the file to CRLF and produced a whole-file diff; converted back to LF so the diff is **15 insertions / 27 deletions across 7 files**, all substantive.

## Context Snapshot

See `agents/build-agent/sessions/active-context.md` at commit `8538be8` (voperations/build-agent). Reproduced inline below at PR-open time:

```yaml
agent: build-agent
last_updated: 2026-08-20T08:15:00Z
north_star: Run a full review of everything local and deployed, fix/improve what needs fixing, and report done-vs-planned.
current_task: Executing the verified fix plan from the 7-dimension review workflow (wfed48rxr).
next_action: Continue the fix plan; then write the done-vs-planned report.
status: active
Demand evidence: owner directive this session, verbatim — "run full review of all we have locally and deployed / improve fix all you find that need fix"
```

Landed earlier this session (all pushed): content-inclusive DR backup + proven restore; boot-check checks 4b/4c/4d/4e; go-git 5.19.2 gated and merged (`028892ef3`, closes a HIGH advisory); INFRASTRUCTURE.md and CI-runner-routing corrections; `make` and Node installed so lint and site builds are locally verifiable; 5 stale ops issues closed with evidence.

## Linked

- ops#457 — install page ships broken copy-paste commands + false "Signed" badge (this PR)
- **ops#739** — `docplatform init` fails 100% (the reason `init` is removed rather than corrected)
- ops#242 — CLI-init orphaning / no first-user-admin flow (the same fork ops#739 needs decided)
- ops#108 / ops#274 — Windows binaries unsigned (why the pill was false)
- ops#716 — the loop profile denies `valoryx.org` to headless firings, which is why this board item sat unclaimable
